### PR TITLE
feat: support passphrase from file or command (closes #53)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,21 @@
 # Required: SSH URL to your Borg repository
 BORG_REPO=ssh://user@backup-server.example.com:22/~/backups/my-backup
 
-# Required: Repository encryption passphrase
+# Required: Repository encryption passphrase (one of the three options below).
 # IMPORTANT: Keep this secure! Without it, you cannot restore your backups.
+#
+# Option 1 - passphrase directly in this var (simplest):
 BORG_PASSPHRASE=your-strong-passphrase-here
+#
+# Option 2 - read the passphrase from a mounted file (e.g. on an encrypted
+# dataset) so it never lives in the orchestrator's stored config:
+# BORG_PASSPHRASE_FILE=/run/secrets/passphrase
+#
+# Option 3 - borg-native; keeps the passphrase out of the environment entirely:
+# BORG_PASSCOMMAND=cat /run/secrets/passphrase
+#
+# See the "Protecting the Passphrase" section of the README for the TrueNAS
+# encrypted-dataset threat model and which option to choose.
 
 # Required: Colon-separated paths to backup (container paths)
 # These correspond to the mounted volumes in docker-compose.yml

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -38,11 +38,8 @@ jobs:
             sudo apt-get update && sudo apt-get install -y shellcheck
           fi
 
-          # Find and check all shell scripts
-          find . -name "*.sh" -type f | while read -r script; do
-            echo "Checking $script..."
-            shellcheck "$script" || exit 1
-          done
+          # Single source of truth: same lint target developers run locally
+          make lint
 
       - name: Validate VERSION file
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,15 @@ docker run --rm -it \
 
 ## Testing
 
+### Linting
+
+All shell scripts are checked with [shellcheck](https://www.shellcheck.net/) (the same check CI runs):
+
+```bash
+make lint     # shellcheck every *.sh
+make check    # lint + unit tests - the quick pre-push gate
+```
+
 ### Unit Tests
 
 All shell scripts are covered by [bats-core](https://github.com/bats-core/bats-core) unit tests.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: test test-alpine test-e2e build
+.PHONY: lint test test-alpine test-e2e check build
+
+# Shellcheck every shell script (mirrors the CI pr-validation step)
+lint:
+	@find . -name '*.sh' -type f -not -path './.git/*' -print0 | xargs -0 shellcheck
 
 # Run unit tests locally (requires bats-core: brew/apt install bats)
 test:
@@ -14,6 +18,9 @@ test-alpine:
 # Uses docker-compose.e2e.yml; requires Docker and Docker Compose v2
 test-e2e:
 	@bash tests/e2e/run.sh
+
+# Lint + unit tests - the quick local pre-push gate
+check: lint test
 
 build:
 	docker build -t docker-borg-client .

--- a/README.md
+++ b/README.md
@@ -228,7 +228,9 @@ If prompted for password, SSH key is not configured correctly on remote server.
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `BORG_REPO` | Yes | - | Full SSH URL to repository (e.g., `ssh://user@host:22/~/backup`) |
-| `BORG_PASSPHRASE` | Yes | - | Repository encryption passphrase |
+| `BORG_PASSPHRASE` | Yes* | - | Repository encryption passphrase. *One of `BORG_PASSPHRASE`, `BORG_PASSPHRASE_FILE`, or `BORG_PASSCOMMAND` is required. |
+| `BORG_PASSPHRASE_FILE` | No | - | Path to a file containing the passphrase (read at startup). Mount from an encrypted dataset to keep the secret off the apps pool. |
+| `BORG_PASSCOMMAND` | No | - | Command that prints the passphrase (e.g. `cat /run/secrets/passphrase`). Borg-native; keeps the secret out of the environment entirely. |
 | `BACKUP_PATHS` | Yes | - | Colon-separated paths to back up (e.g., `/data/photos:/data/docs`) |
 | `BACKUP_EXCLUDES` | No | - | Colon-separated paths/patterns to exclude (e.g., `/data/photos/cache:/data/docs/tmp`) |
 | `BORG_RSH` | No | `ssh -i /ssh/key -o StrictHostKeyChecking=accept-new` | SSH command |
@@ -598,6 +600,30 @@ docker compose run --rm borg-backup /scripts/restore.sh check
 - Deleting `/borg/cache` or `/borg/config` - Can corrupt repository metadata
 
 **Recommendation**: Test your restore process regularly to ensure backups are working correctly.
+
+### Protecting the Passphrase (TrueNAS encrypted datasets)
+
+> **If you back up an *encrypted* dataset, read this.** A naive setup can quietly weaken its protection.
+
+Borg encrypts data **client-side**: it trusts the client and distrusts the backup server. Recovery needs two things — the repository key (stored encrypted *inside* the repo) and the **passphrase** (which must live only on the client). An attacker who compromises only the backup server gets ciphertext they cannot read.
+
+The risk on TrueNAS is **where the passphrase lives**. The TrueNAS Apps pool (and the `ix-apps` dataset) is **not encrypted**. If you set `BORG_PASSPHRASE` as a plain environment variable, that value is stored in the app's configuration on that unencrypted pool. An attacker who reads the unencrypted apps pool then has the passphrase — and combined with access to the backup server (often trivially reachable from the same machine via the SSH key) they can decrypt the backup of your *encrypted* dataset. In effect, the encrypted dataset is only as protected as the unencrypted pool.
+
+**Mitigations** (any one closes the gap; later options are stronger):
+
+1. **Keep the SSH key on an encrypted dataset.** The key is already a mounted file (`/ssh/key`), never an env var. Mount it from an encrypted dataset so the backup server is unreachable while that dataset is locked.
+
+2. **Supply the passphrase from a file on an encrypted dataset** instead of an env var. Use either:
+   - **`env_file`** pointing at a file on an encrypted dataset (keeps the plaintext out of the app config — note the value still becomes a normal container env var, visible via `docker inspect`), or
+   - **`BORG_PASSPHRASE_FILE=/run/secrets/passphrase`** — this container reads the file at startup.
+
+3. **`BORG_PASSCOMMAND` (strongest).** Borg-native; the passphrase is never stored as an environment variable at all:
+   ```bash
+   BORG_PASSCOMMAND=cat /run/secrets/passphrase
+   ```
+   Mount `/run/secrets/passphrase` from an encrypted dataset. While the dataset is locked, the passphrase is unavailable and the backup cannot be decrypted.
+
+**Threat model summary** — backing up an encrypted dataset with the passphrase on the unencrypted pool adds a new path for an attacker: instead of needing the dataset open (or its key), they need only the unencrypted pool **plus** server access. Keeping the passphrase (and SSH key) on encrypted storage removes that path.
 
 ## Disaster Recovery
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,8 +17,20 @@ if [ -z "$BORG_REPO" ]; then
     exit 1
 fi
 
-if [ -z "$BORG_PASSPHRASE" ]; then
-    echo "ERROR: BORG_PASSPHRASE environment variable is required"
+# Support the Docker secret convention: read the passphrase from a mounted file
+# (e.g. on an encrypted dataset) so it never lives in the orchestrator's config.
+if [ -n "${BORG_PASSPHRASE_FILE:-}" ] && [ -f "$BORG_PASSPHRASE_FILE" ]; then
+    BORG_PASSPHRASE=$(cat "$BORG_PASSPHRASE_FILE")
+    export BORG_PASSPHRASE
+fi
+
+# A passphrase must be available via one of three mechanisms. BORG_PASSCOMMAND
+# is borg-native and keeps the secret out of the environment entirely.
+if [ -z "${BORG_PASSPHRASE:-}" ] && [ -z "${BORG_PASSCOMMAND:-}" ]; then
+    echo "ERROR: a passphrase is required - set one of:"
+    echo "  BORG_PASSPHRASE       (passphrase in env var)"
+    echo "  BORG_PASSPHRASE_FILE  (path to a file containing the passphrase)"
+    echo "  BORG_PASSCOMMAND      (command that prints the passphrase, e.g. 'cat /run/secrets/passphrase')"
     exit 1
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,8 +5,17 @@ set -e
 BORG_RSH="${BORG_RSH:-ssh -i /ssh/key -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -o ConnectionAttempts=3}"
 export BORG_RSH
 
+# Support the Docker secret convention: read the passphrase from a mounted file
+# (e.g. on an encrypted dataset) so it never lives in the orchestrator's config.
+# Done before the direct-command passthrough so manual ops (docker run image
+# /scripts/backup.sh) also benefit from the file-based passphrase.
+if [ -n "${BORG_PASSPHRASE_FILE:-}" ] && [ -f "$BORG_PASSPHRASE_FILE" ]; then
+    BORG_PASSPHRASE=$(cat "$BORG_PASSPHRASE_FILE")
+    export BORG_PASSPHRASE
+fi
+
 # If a command is passed directly (e.g. docker run image /scripts/verify.sh),
-# skip daemon setup and run it immediately with the SSH env already set.
+# skip daemon setup and run it immediately with the SSH/passphrase env already set.
 if [ $# -gt 0 ]; then
     exec "$@"
 fi
@@ -15,13 +24,6 @@ fi
 if [ -z "$BORG_REPO" ]; then
     echo "ERROR: BORG_REPO environment variable is required"
     exit 1
-fi
-
-# Support the Docker secret convention: read the passphrase from a mounted file
-# (e.g. on an encrypted dataset) so it never lives in the orchestrator's config.
-if [ -n "${BORG_PASSPHRASE_FILE:-}" ] && [ -f "$BORG_PASSPHRASE_FILE" ]; then
-    BORG_PASSPHRASE=$(cat "$BORG_PASSPHRASE_FILE")
-    export BORG_PASSPHRASE
 fi
 
 # A passphrase must be available via one of three mechanisms. BORG_PASSCOMMAND

--- a/tests/e2e/client-test.sh
+++ b/tests/e2e/client-test.sh
@@ -77,4 +77,31 @@ grep -q "This file must be present" /tmp/restore/source/important.txt \
     || fail "Restored content does not match original"
 pass "Restore verified"
 
+# ---------- passphrase from file (issue #53) ----------
+# Drive a real backup through the entrypoint with the passphrase sourced from a
+# mounted file instead of BORG_PASSPHRASE, proving the resolution path works
+# against the real server (not just the unit-test snippet).
+
+step "Backup with BORG_PASSPHRASE_FILE (passphrase env unset)"
+printf '%s' "$BORG_PASSPHRASE" > /tmp/pass.secret
+COUNT_BEFORE=$(borg list "$REPO" | wc -l)
+env -u BORG_PASSPHRASE BORG_PASSPHRASE_FILE=/tmp/pass.secret \
+    /entrypoint.sh /scripts/backup.sh
+COUNT_AFTER=$(borg list "$REPO" | wc -l)
+[ "$COUNT_AFTER" -gt "$COUNT_BEFORE" ] \
+    || fail "BORG_PASSPHRASE_FILE backup did not create a new archive"
+pass "Passphrase-from-file backup succeeded"
+
+# ---------- passphrase from command (issue #53) ----------
+# BORG_PASSCOMMAND is borg-native: the passphrase never enters the environment.
+
+step "Backup with BORG_PASSCOMMAND (passphrase env unset)"
+COUNT_BEFORE=$(borg list "$REPO" | wc -l)
+env -u BORG_PASSPHRASE BORG_PASSCOMMAND="cat /tmp/pass.secret" \
+    /entrypoint.sh /scripts/backup.sh
+COUNT_AFTER=$(borg list "$REPO" | wc -l)
+[ "$COUNT_AFTER" -gt "$COUNT_BEFORE" ] \
+    || fail "BORG_PASSCOMMAND backup did not create a new archive"
+pass "Passphrase-from-command backup succeeded"
+
 step "All E2E tests passed"

--- a/tests/entrypoint.bats
+++ b/tests/entrypoint.bats
@@ -27,6 +27,8 @@ teardown() {
     rm -rf "$BORG_REPO"
     unset BORG_REPO
     unset BORG_PASSPHRASE
+    unset BORG_PASSPHRASE_FILE
+    unset BORG_PASSCOMMAND
     unset BACKUP_PATHS
     unset BORG_CACHE_DIR
     unset AUTO_INIT
@@ -307,4 +309,94 @@ EOF
     run sh "$TEST_DIR/cron-test.sh"
     [ "$status" -eq 0 ]
     echo "$output" | grep -q "0 5 15 \* \* VERIFY_LEVEL=archives /scripts/verify.sh"
+}
+
+# Helper to create passphrase-resolution test script (mirrors entrypoint.sh logic)
+create_passphrase_test_script() {
+    cat > "$TEST_DIR/passphrase-test.sh" << 'EOF'
+#!/bin/sh
+set -e
+
+# Support the Docker secret convention: read the passphrase from a mounted file
+if [ -n "${BORG_PASSPHRASE_FILE:-}" ] && [ -f "$BORG_PASSPHRASE_FILE" ]; then
+    BORG_PASSPHRASE=$(cat "$BORG_PASSPHRASE_FILE")
+    export BORG_PASSPHRASE
+fi
+
+# A passphrase must be available via one of three mechanisms
+if [ -z "${BORG_PASSPHRASE:-}" ] && [ -z "${BORG_PASSCOMMAND:-}" ]; then
+    echo "ERROR: a passphrase is required"
+    exit 1
+fi
+
+echo "RESOLVED_PASSPHRASE=${BORG_PASSPHRASE:-}"
+echo "PASSPHRASE_OK"
+EOF
+    chmod +x "$TEST_DIR/passphrase-test.sh"
+}
+
+# Test: BORG_PASSPHRASE env var is accepted (existing behaviour)
+@test "accepts BORG_PASSPHRASE env var" {
+    create_passphrase_test_script
+    export BORG_PASSPHRASE="env-passphrase"
+    unset BORG_PASSPHRASE_FILE
+    unset BORG_PASSCOMMAND
+
+    run sh "$TEST_DIR/passphrase-test.sh"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "PASSPHRASE_OK"
+    echo "$output" | grep -q "RESOLVED_PASSPHRASE=env-passphrase"
+}
+
+# Test: BORG_PASSPHRASE_FILE is read from disk
+@test "reads passphrase from BORG_PASSPHRASE_FILE" {
+    create_passphrase_test_script
+    unset BORG_PASSPHRASE
+    unset BORG_PASSCOMMAND
+    printf 'file-passphrase' > "$TEST_DIR/passphrase.secret"
+    export BORG_PASSPHRASE_FILE="$TEST_DIR/passphrase.secret"
+
+    run sh "$TEST_DIR/passphrase-test.sh"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "PASSPHRASE_OK"
+    echo "$output" | grep -q "RESOLVED_PASSPHRASE=file-passphrase"
+}
+
+# Test: BORG_PASSCOMMAND alone satisfies validation (no passphrase in env)
+@test "accepts BORG_PASSCOMMAND without BORG_PASSPHRASE" {
+    create_passphrase_test_script
+    unset BORG_PASSPHRASE
+    unset BORG_PASSPHRASE_FILE
+    export BORG_PASSCOMMAND="cat /run/secrets/passphrase"
+
+    run sh "$TEST_DIR/passphrase-test.sh"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "PASSPHRASE_OK"
+    # Passphrase is intentionally NOT in the env - borg resolves it via the command
+    echo "$output" | grep -q "RESOLVED_PASSPHRASE=$"
+}
+
+# Test: fails when no passphrase mechanism is provided
+@test "fails when no passphrase mechanism is set" {
+    create_passphrase_test_script
+    unset BORG_PASSPHRASE
+    unset BORG_PASSPHRASE_FILE
+    unset BORG_PASSCOMMAND
+
+    run sh "$TEST_DIR/passphrase-test.sh"
+    [ "$status" -eq 1 ]
+    echo "$output" | grep -q "a passphrase is required"
+}
+
+# Test: BORG_PASSPHRASE_FILE takes precedence over BORG_PASSPHRASE env var
+@test "BORG_PASSPHRASE_FILE overrides BORG_PASSPHRASE env var" {
+    create_passphrase_test_script
+    export BORG_PASSPHRASE="env-passphrase"
+    printf 'file-passphrase' > "$TEST_DIR/passphrase.secret"
+    export BORG_PASSPHRASE_FILE="$TEST_DIR/passphrase.secret"
+    unset BORG_PASSCOMMAND
+
+    run sh "$TEST_DIR/passphrase-test.sh"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "RESOLVED_PASSPHRASE=file-passphrase"
 }


### PR DESCRIPTION
## Summary

Closes #53. Lets the Borg passphrase come from a mounted file or a command instead of only a plain environment variable, so users backing up **encrypted TrueNAS datasets** can keep the secret off the unencrypted apps pool.

## What changed

- **entrypoint.sh**: a passphrase may now be supplied via any one of:
  - `BORG_PASSPHRASE` — env var (unchanged)
  - `BORG_PASSPHRASE_FILE` — path to a file read at startup (Docker secret convention)
  - `BORG_PASSCOMMAND` — borg-native; keeps the secret out of the environment entirely

  Validation now requires *one of* the three rather than only the env var (this also fixes a latent bug where `BORG_PASSCOMMAND`-only setups were rejected at startup).
- **README**: new *Protecting the Passphrase* section documenting the TrueNAS encrypted-dataset threat model and the three mitigations (per the issue's request for an informed-decision writeup).
- **.env.example**: documents all three options.
- **Tooling**: added `make lint` (shellcheck) and `make check` (lint + test); `pr-validation` CI now calls `make lint` as the single source of truth.
- **Tests**: 5 new bats cases covering passphrase resolution + validation (110 total, all green). E2E suite still passes.

## Compatibility

Fully additive — existing `BORG_PASSPHRASE` deployments are unaffected and need no changes or re-testing.